### PR TITLE
update to work with rmarkdown 2.7 and bslib support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,3 +20,4 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
+Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Title: Slimmed-down alternative to rmarkdown::html_document
 Version: 0.1.0
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut", "cre"), email = "joe@rstudio.com"),
+    person("christophe", "Dervieux", role = c("ctb"), email = "cderv@rstudio.com"),
     person(family = "RStudio", role = "cph"),
     person(family = "Bootstrap contributors", role = "ctb",
       comment = "Bootstrap library")
@@ -12,13 +13,10 @@ Description: Provides a document format similar to rmarkdown::html_document but
     with a slimmed-down Bootstrap derivative instead of the real thing.
 Imports:
     utils,
-    rmarkdown (>= 2.1.1),
+    rmarkdown (>= 2.7),
     htmltools,
     jquerylib
-Remotes:
-    rstudio/rmarkdown#1706,
-    rstudio/jquerylib
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1

--- a/R/document_format.R
+++ b/R/document_format.R
@@ -66,23 +66,13 @@ rstrap_document <- function(toc = FALSE,
     )
   }
 
-  if (!"bootstrap_version" %in% names(formals(rmarkdown::html_document_base))) {
-    stop(call. = FALSE,
-      "The `rstrap_document` output format requires a newer version of ",
-      "the `rmarkdown` package (try ",
-      "`renv::install(\"rstudio/rmarkdown#1706\")`).",
-      " Some document features may not work properly."
-    )
-  }
-
   extra_dependencies <- c(
     html_dependencies_rstrap(),
     extra_dependencies
   )
 
   rmarkdown::html_document(
-    bootstrap_version = "4",
-
+    theme = list(version = 4),
     toc = toc,
     toc_depth = toc_depth,
     toc_float = toc_float,

--- a/R/document_format.R
+++ b/R/document_format.R
@@ -1,6 +1,8 @@
 html_dependencies_rstrap <- function() {
   list(
+    # use last jquery
     jquerylib::jquery_core(3),
+    # custom deps forked from boostrap
     htmltools::htmlDependency(
       "rstrap",
       utils::packageVersion("rsformat"),
@@ -10,6 +12,8 @@ html_dependencies_rstrap <- function() {
       script = "rstrap.js",
       all_files = FALSE
     ),
+    # this is required so another bootstrap deps is not used.
+    # this is to trick htmltools::resolveDependencies() in keeping this dummy one.
     htmltools::htmlDependency(
       "bootstrap",
       "99999.0.0",

--- a/R/document_format.R
+++ b/R/document_format.R
@@ -31,7 +31,11 @@ html_dependencies_rstrap <- function() {
 #'
 #' @inheritParams rmarkdown::html_document
 #'
-#' @seealso rmarkdown::html_document
+#' @seealso [rmarkdown::html_document()]
+#' @param theme `NULL`. For this format, it can't be set to another value or it
+#'   will error.
+#' @param css CSS and/or Sass files to include. Files with an extension of .sass
+#' or .scss are compiled to CSS via `sass::sass()`.
 #'
 #' @export
 rstrap_document <- function(toc = FALSE,

--- a/man/rstrap_document.Rd
+++ b/man/rstrap_document.Rd
@@ -46,8 +46,8 @@ options that control the behavior of the floating table of contents. See the
 
 \item{number_sections}{\code{TRUE} to number section headings}
 
-\item{section_divs}{Wrap sections in <div> tags, and attach identifiers to the
-enclosing <div> rather than the header itself.}
+\item{section_divs}{Wrap sections in \code{<div>} tags, and attach identifiers to the
+enclosing \code{<div>} rather than the header itself.}
 
 \item{fig_width}{Default width (in inches) for figures}
 
@@ -73,7 +73,9 @@ method creates a paginated HTML table (note that this method is only valid
 for formats that produce HTML). In addition to the named methods you can
 also pass an arbitrary function to be used for printing data frames. You
 can disable the \code{df_print} behavior entirely by setting the option
-\code{rmarkdown.df_print} to \code{FALSE}.}
+\code{rmarkdown.df_print} to \code{FALSE}. See
+\href{https://bookdown.org/yihui/rmarkdown/html-document.html#data-frame-printing}{Data
+frame printing section} in bookdown book for examples.}
 
 \item{code_folding}{Enable document readers to toggle the display of R code
 chunks. Specify \code{"none"} to display all code chunks (assuming
@@ -85,27 +87,14 @@ chunks by default.}
 \item{code_download}{Embed the Rmd source code within the document and provide
 a link that can be used by readers to download the code.}
 
-\item{smart}{Produce typographically correct output, converting straight
-quotes to curly quotes, \code{---} to em-dashes, \code{--} to en-dashes, and
-\code{...} to ellipses.}
-
 \item{self_contained}{Produce a standalone HTML file with no external
 dependencies, using data: URIs to incorporate the contents of linked
 scripts, stylesheets, images, and videos. Note that even for self contained
 documents MathJax is still loaded externally (this is necessary because of
 its size).}
 
-\item{theme}{Visual theme ("default", "cerulean", "cosmo", "cyborg", "darkly",
-"flatly", "journal", "lumen", "readable", "sandstone", "simplex", "slate",
-"spacelab", "superhero", "united", or "yeti"). Pass \code{NULL} for no
-theme (in this case you can use the \code{css} parameter to add your own styles).
-If Bootstrap 4+ is used (see \code{bootstrap_version} argument),
-a handful of other themes are available ("lux", "minty", "pulse",
-"sketchy", and "solar"). Moreover, with Bootstrap 4+, custom
-\href{https://getbootstrap.com/docs/4.0/getting-started/theming/}{Bootstrap
-themes} are supported via the \code{bs_theme_add_variables()} and
-\code{bs_theme_add()} functions from the bootstraplib package
-(use these functions from within the document).}
+\item{theme}{\code{NULL}. For this format, it can't be set to another value or it
+will error.}
 
 \item{highlight}{Syntax highlighting style. Supported styles include
 "default", "tango", "pygments", "kate", "monochrome", "espresso", "zenburn",
@@ -126,7 +115,8 @@ more details).}
 \item{extra_dependencies}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link[rmarkdown]{html_document_base}}}
 
-\item{css}{One or more css files to include}
+\item{css}{CSS and/or Sass files to include. Files with an extension of .sass
+or .scss are compiled to CSS via \code{sass::sass()}.}
 
 \item{includes}{Named list of additional content to include within the
 document (typically created using the \code{\link[rmarkdown]{includes}} function).}
@@ -147,10 +137,10 @@ additional details.}
 base R Markdown HTML output formatter \code{\link[rmarkdown]{html_document_base}}}
 }
 \description{
-A substitute for the [rmarkdown::html_document()] format which uses a slimmed
+A substitute for the \code{\link[rmarkdown:html_document]{rmarkdown::html_document()}} format which uses a slimmed
 down version of Bootstrap 4. All arguments below behave the same as their
-[rmarkdown::html_document()] equivalents.
+\code{\link[rmarkdown:html_document]{rmarkdown::html_document()}} equivalents.
 }
 \seealso{
-rmarkdown::html_document
+\code{\link[rmarkdown:html_document]{rmarkdown::html_document()}}
 }


### PR DESCRIPTION
Hey @jcheng5 , This changes makes the format usable with last **rmarkdown** and changes since the PR that introduced **bslib** support. 

It seems I don't have the right to admin this repo so I can't push to master. So, here is a PR 😄 

This will serve as base to next work to try include this into **rmarkdown** directly. 

@apreshill, this will make the current solution with **rsformat** usable for some tries if you want